### PR TITLE
#issue19 actions receive no payload

### DIFF
--- a/src/Dispatchers/WordpressDispatcher.php
+++ b/src/Dispatchers/WordpressDispatcher.php
@@ -181,6 +181,7 @@
 
             $filtered = $this->hook_api->applyFilter( $event, $payload );
 
+
             if ( $filtered === $payload || ! $this->isCorrectReturnValue($payload, $filtered) ) {
 
                 return $this->determineDefault($payload, $filtered);

--- a/src/Dispatchers/WordpressDispatcher.php
+++ b/src/Dispatchers/WordpressDispatcher.php
@@ -173,7 +173,7 @@
 
             $this->maybeStopPropagation($event);
 
-            if ( ! $this->hasListeners($event)) {
+            if ( ! $this->hasListeners($event) ) {
 
                 return $this->determineDefault($payload, null);
 

--- a/src/Dispatchers/WordpressDispatcher.php
+++ b/src/Dispatchers/WordpressDispatcher.php
@@ -179,9 +179,9 @@
 
             }
 
-            $filtered = $this->hook_api->applyFilter($event, $payload);
+            $filtered = $this->hook_api->applyFilter( $event, $payload );
 
-            if ($filtered === $payload || ! $this->isCorrectReturnValue($payload, $filtered)) {
+            if ( $filtered === $payload || ! $this->isCorrectReturnValue($payload, $filtered) ) {
 
                 return $this->determineDefault($payload, $filtered);
 
@@ -495,7 +495,6 @@
          */
         private function parseEventAndPayload($event, $payload) : array
         {
-
 
             if (is_object($event)) {
 

--- a/src/Testing/BetterWpHooksTestCase.php
+++ b/src/Testing/BetterWpHooksTestCase.php
@@ -29,6 +29,7 @@
             $GLOBALS['wp_filter']         = [];
             $GLOBALS['wp_actions']        = [];
             $GLOBALS['wp_current_filter'] = [];
+            $GLOBALS['test'] = [];
 
 			
 		}

--- a/src/Traits/IsAction.php
+++ b/src/Traits/IsAction.php
@@ -1,0 +1,15 @@
+<?php
+
+
+    declare(strict_types = 1);
+
+
+    namespace BetterWpHooks\Traits;
+
+    /**
+     * @codeCoverageIgnore
+     */
+    trait IsAction
+    {
+
+    }

--- a/src/WordpressApi.php
+++ b/src/WordpressApi.php
@@ -1,20 +1,29 @@
 <?php
-	
-	namespace BetterWpHooks;
+
+
+    declare(strict_types = 1);
+
+
+    namespace BetterWpHooks;
 	
 
-    /**
-	 *
-	 * Simple Wrapper Class around the Wordpress Plugin Api
-	 * Used to allow swapping during testing.
-	 *
-	 * Class WordpressApi
-	 *
-	 * @package BetterWpHooks
-	 */
+    use BetterWpHooks\Traits\IsAction;
+
+    use function BetterWpHooks\Functions\classExists;
+
+
 	class WordpressApi {
 
 		public function applyFilter( $event , ...$payload ) {
+
+		    if ( $this->isDispatchingAction($event) ) {
+
+		        do_action($event, ...$payload);
+
+		        // stay close to WP which also return '' for do_action()
+		        return '';
+
+            }
 
 			return apply_filters( $event, ...$payload );
 			
@@ -44,6 +53,18 @@
 			add_filter( $event, $listener, $priority, $args );
 			
 		}
-		
+
+		private function isDispatchingAction( $event ) : bool
+        {
+
+            if ( classExists($event) && in_array(IsAction::class, class_uses($event) ) ) {
+
+                return true;
+
+            }
+
+            return false;
+
+        }
 		
 	}

--- a/src/WordpressApi.php
+++ b/src/WordpressApi.php
@@ -2,7 +2,8 @@
 	
 	namespace BetterWpHooks;
 	
-	/**
+
+    /**
 	 *
 	 * Simple Wrapper Class around the Wordpress Plugin Api
 	 * Used to allow swapping during testing.
@@ -12,14 +13,13 @@
 	 * @package BetterWpHooks
 	 */
 	class WordpressApi {
-		
-		public function applyFilter( $event, ...$payload ) {
-			
+
+		public function applyFilter( $event , ...$payload ) {
+
 			return apply_filters( $event, ...$payload );
 			
 		}
-		
-		
+
 		public function hasFilterFor( $event, $callback = NULL ): bool {
 			
 			// WP returns the hook priority if a hook exists and a cb is passed

--- a/tests/TestEvents/ActionEvent.php
+++ b/tests/TestEvents/ActionEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+
+    declare(strict_types = 1);
+
+
+    namespace Tests\TestEvents;
+
+    use BetterWpHooks\Traits\IsAction;
+
+    class ActionEvent
+    {
+        use IsAction;
+
+    }

--- a/tests/TestEvents/EventFakeStub.php
+++ b/tests/TestEvents/EventFakeStub.php
@@ -5,5 +5,7 @@
 	class EventFakeStub {
 		
 		public $creator;
-		
-	}
+
+
+
+    }

--- a/tests/Unit/WordpressDispatcherTest.php
+++ b/tests/Unit/WordpressDispatcherTest.php
@@ -11,12 +11,14 @@
     use BetterWpHooks\Testing\BetterWpHooksTestCase;
     use BetterWpHooks\WordpressApi;
 	use Codeception\AssertThrows;
-	use SniccoAdapter\BaseContainerAdapter;
+    use Illuminate\Support\Facades\Event;
+    use SniccoAdapter\BaseContainerAdapter;
 	use stdClass;
 	use Tests\CustomAssertions;
 	use Tests\TestDependencies\ComplexListener;
 	use Tests\TestDependencies\ComplexMethodDependency;
 	use Tests\TestEvents\ConditionalEvent;
+    use Tests\TestEvents\EventFakeStub;
     use Tests\TestEvents\EventWithDefaultLogic;
     use Tests\TestEvents\EventWithDefaultNoTypeHit;
     use Tests\TestEvents\EventWithDefaults;
@@ -1181,7 +1183,30 @@
 
         }
 
+        /** @test */
+        public function wordpress_actions_work_and_receive_the_same_payload_without_needing_a_return_value () {
 
+            $event = new EventFakeStub();
+
+            $closure1 = function (EventFakeStub $event_object) use ($event) {
+
+                $this->assertSame($event_object, $event);
+
+            };
+
+            $closure2 = function (EventFakeStub $event_object) use ($event) {
+
+                $this->assertSame($event_object, $event);
+
+
+            };
+
+            $this->dispatcher->listen(EventFakeStub::class, $closure1);
+            $this->dispatcher->listen(EventFakeStub::class, $closure2);
+
+            $this->dispatcher->dispatch( $event);
+
+        }
 
 		private function reset(): void {
 			

--- a/tests/Unit/WordpressDispatcherTest.php
+++ b/tests/Unit/WordpressDispatcherTest.php
@@ -1191,21 +1191,32 @@
 
             $closure1 = function (ActionEvent $event_object) use ($event) {
 
+                $GLOBALS['test']['closure1'] = true;
+
+
                 $this->assertSame($event_object, $event);
 
             };
 
             $closure2 = function (ActionEvent $event_object) use ($event) {
 
+                $GLOBALS['test']['closure2'] = true;
+
                 $this->assertSame($event_object, $event);
 
 
             };
 
+            $GLOBALS['test']['closure1'] = false;
+            $GLOBALS['test']['closure2'] = false;
+
             $this->dispatcher->listen(ActionEvent::class, $closure1);
             $this->dispatcher->listen(ActionEvent::class, $closure2);
 
             $this->dispatcher->dispatch( $event );
+
+            $this->assertTrue($GLOBALS['test']['closure1']);
+            $this->assertTrue($GLOBALS['test']['closure2']);
 
         }
 

--- a/tests/Unit/WordpressDispatcherTest.php
+++ b/tests/Unit/WordpressDispatcherTest.php
@@ -17,7 +17,8 @@
 	use Tests\CustomAssertions;
 	use Tests\TestDependencies\ComplexListener;
 	use Tests\TestDependencies\ComplexMethodDependency;
-	use Tests\TestEvents\ConditionalEvent;
+    use Tests\TestEvents\ActionEvent;
+    use Tests\TestEvents\ConditionalEvent;
     use Tests\TestEvents\EventFakeStub;
     use Tests\TestEvents\EventWithDefaultLogic;
     use Tests\TestEvents\EventWithDefaultNoTypeHit;
@@ -1186,25 +1187,25 @@
         /** @test */
         public function wordpress_actions_work_and_receive_the_same_payload_without_needing_a_return_value () {
 
-            $event = new EventFakeStub();
+            $event = new ActionEvent();
 
-            $closure1 = function (EventFakeStub $event_object) use ($event) {
+            $closure1 = function (ActionEvent $event_object) use ($event) {
 
                 $this->assertSame($event_object, $event);
 
             };
 
-            $closure2 = function (EventFakeStub $event_object) use ($event) {
+            $closure2 = function (ActionEvent $event_object) use ($event) {
 
                 $this->assertSame($event_object, $event);
 
 
             };
 
-            $this->dispatcher->listen(EventFakeStub::class, $closure1);
-            $this->dispatcher->listen(EventFakeStub::class, $closure2);
+            $this->dispatcher->listen(ActionEvent::class, $closure1);
+            $this->dispatcher->listen(ActionEvent::class, $closure2);
 
-            $this->dispatcher->dispatch( $event);
+            $this->dispatcher->dispatch( $event );
 
         }
 


### PR DESCRIPTION
It's now possible to assign many listeners to an event without having to return the event object for actions.