### PR TITLE
issue#26 allow multiple action events to be mapped to one core hook.

### DIFF
--- a/src/BetterWpHooks.php
+++ b/src/BetterWpHooks.php
@@ -119,7 +119,7 @@
 
             try {
 
-                foreach ($this->mapped_events as $hook_name => $mapped_event) {
+                foreach ($this->mapped_events as $hook_name => $mapped_events) {
 
                     if ( ! $hook_name) {
 
@@ -127,7 +127,13 @@
 
                     }
 
-                    $this->event_mapper->listen($hook_name, $mapped_event);
+                    foreach ($mapped_events as $mapped_event) {
+
+                        $this->event_mapper->listen($hook_name, $mapped_event);
+
+
+                    }
+
 
 
                 }
@@ -135,7 +141,7 @@
             }
             catch (\Throwable $e) {
 
-                throw new ConfigurationException('Invalid Data was provided for event-mapping: '.$e->getMessage());
+                throw new ConfigurationException('Invalid Data was provided for event-mapping:' . PHP_EOL .$e->getMessage());
 
             }
 

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -70,7 +70,7 @@
         /**
          * Returns the dispatcher instance
          *
-         * @return WordpressDispatcher | FakeDispatcher
+         * @return WordpressDispatcher|FakeDispatcher
          */
         public static function dispatcher()
         {

--- a/src/WordpressApi.php
+++ b/src/WordpressApi.php
@@ -16,7 +16,7 @@
 
 		public function applyFilter( $event , ...$payload ) {
 
-		    if ( $this->isDispatchingAction($event) ) {
+		    if ( $this->isAction($event) ) {
 
 		        do_action($event, ...$payload);
 
@@ -54,7 +54,7 @@
 			
 		}
 
-		private function isDispatchingAction( $event ) : bool
+		public function isAction( $event ) : bool
         {
 
             if ( classExists($event) && in_array(IsAction::class, class_uses($event) ) ) {
@@ -66,5 +66,7 @@
             return false;
 
         }
+
+
 		
 	}

--- a/tests/TestEvents/ActionEvent.php
+++ b/tests/TestEvents/ActionEvent.php
@@ -7,8 +7,9 @@
     namespace Tests\TestEvents;
 
     use BetterWpHooks\Traits\IsAction;
+    use Tests\TestStubs\Plugin1;
 
-    class ActionEvent
+    class ActionEvent extends Plugin1
     {
         use IsAction;
 

--- a/tests/TestEvents/ActionEvent2.php
+++ b/tests/TestEvents/ActionEvent2.php
@@ -1,0 +1,29 @@
+<?php
+
+
+    declare(strict_types = 1);
+
+
+    namespace Tests\TestEvents;
+
+    use BetterWpHooks\Traits\IsAction;
+    use Tests\TestDependencies\Dependency;
+    use Tests\TestStubs\Plugin1;
+
+    class ActionEvent2 extends Plugin1
+    {
+
+        use IsAction;
+
+        /**
+         * @var Dependency
+         */
+        private $dependency;
+
+        public function __construct(Dependency $dependency)
+        {
+
+            $this->dependency = $dependency;
+        }
+
+    }

--- a/tests/TestEvents/FilterableEvent.php
+++ b/tests/TestEvents/FilterableEvent.php
@@ -7,7 +7,9 @@
     namespace Tests\TestEvents;
 	
 	
-	class FilterableEvent {
+	use Tests\TestStubs\Plugin1;
+
+    class FilterableEvent extends Plugin1 {
 		
 		
 		public  $foo;


### PR DESCRIPTION
It's now possible to map multiple action events to one core hook as long as the events are exclusively action hooks using the trait

```php 
IsAction::class
```